### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
-  before_action :set_item, only: [:show, :edit, :update, ]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
+  before_action :authenticate_user!, except: [:index, :show]
 
   def index
     @items = Item.order("created_at DESC")
@@ -37,6 +37,15 @@ class ItemsController < ApplicationController
     end
   end
 
+  def destroy
+    if @item.user_id == current_user.id
+      if @item.destroy
+        redirect_to root_path
+      else
+        render :edit
+      end
+    end
+  end
 
   private
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -42,7 +42,7 @@ class ItemsController < ApplicationController
       if @item.destroy
         redirect_to root_path
       else
-        render :show
+        render :edit,status: :unprocessable_entity
       end
     end
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -42,7 +42,7 @@ class ItemsController < ApplicationController
       if @item.destroy
         redirect_to root_path
       else
-        render :edit
+        render :show
       end
     end
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -42,7 +42,7 @@ class ItemsController < ApplicationController
       if @item.destroy
         redirect_to root_path
       else
-        render :edit,status: :unprocessable_entity
+        render :show,status: :unprocessable_entity
       end
     end
   end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,7 +28,7 @@
       <% if current_user.id == @item.user_id %>
         <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
         <p class='or-text'>or</p>
-        <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+        <%= link_to '削除', item_path(@item.id), data: { turbo_method: :delete }, class:'item-destroy' %>
       <% else  %>
         <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
 
-  resources :items, only: [:index, :new, :create, :show, :edit, :update]
+  resources :items
 end


### PR DESCRIPTION
# What
商品削除機能の実装

# Why
商品の情報を削除する機能を実装するため

Gyazo 
ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画:https://gyazo.com/bcfcd53117568fcd3ac26ad88aa8835b


レビューお願いいたします。